### PR TITLE
Changing language to main in code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Mbmore!
 This repository is a collection of custom Cyclus facility archetypes that
 utilize a random number generator (RNG) to create non-deterministic behaviors.
 General methods controlling the behavior (including random number generation
-and Gaussian distributions) are defined in the `behavior functions. <https://github.com/cnerg/mbmore/blob/master/src/behavior_functions.h>`_
+and Gaussian distributions) are defined in the `behavior functions. <https://github.com/cnerg/mbmore/blob/main/src/behavior_functions.h>`_
 
 
 Behavior Functions

--- a/src/CascadeEnrich.h
+++ b/src/CascadeEnrich.h
@@ -8,7 +8,7 @@
 
 /*
 Working with cycamore Develop build:  3ada148442de636d
-cyclus master commit b54c91516c6
+cyclus main commit b54c91516c6
 
 Conceptual Design:
 x Build phase: Design cascade

--- a/src/InteractRegion.cc
+++ b/src/InteractRegion.cc
@@ -116,7 +116,7 @@ std::map<std::string, bool>
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Returns a map of regularly used factors and bool to indicate whether they are
 // defined in this sim.
-std::vector<std::string>& InteractRegion::GetmainFactors() {
+std::vector<std::string>& InteractRegion::GetMainFactors() {
   return column_names;
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/InteractRegion.cc
+++ b/src/InteractRegion.cc
@@ -51,15 +51,15 @@ void InteractRegion::Tick() {
     // Create conflict score map
     BuildScoreMatrix();
     
-    // Define Master List of column names for the database only once.
-    std::string master_factors [] = { "Auth", "Conflict", "Enrich",
+    // Define main List of column names for the database only once.
+    std::string main_factors [] = { "Auth", "Conflict", "Enrich",
 				      "Mil_Iso","Mil_Sp","Reactors",
 				      "Sci_Net", "U_Reserve"};
-    int n_factors = sizeof(master_factors) / sizeof(master_factors[0]);
+    int n_factors = sizeof(main_factors) / sizeof(main_factors[0]);
     
     if (column_names.size() == 0){
       for(int f_it = 0; f_it < n_factors; f_it++) {
-	column_names.push_back(master_factors[f_it]);
+	column_names.push_back(main_factors[f_it]);
       }
     }
     
@@ -116,7 +116,7 @@ std::map<std::string, bool>
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // Returns a map of regularly used factors and bool to indicate whether they are
 // defined in this sim.
-std::vector<std::string>& InteractRegion::GetMasterFactors() {
+std::vector<std::string>& InteractRegion::GetmainFactors() {
   return column_names;
 }
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/InteractRegion.h
+++ b/src/InteractRegion.h
@@ -60,7 +60,7 @@ class InteractRegion
   std::map<std::string, bool> GetDefinedFactors(std::string eqn_type);
 
   // Returns the main list of all factors to be recorded in database
-  std::vector<std::string>& GetmainFactors();
+  std::vector<std::string>& GetMainFactors();
 
   // Tracks weapons status of each state (0 = not pursuing, 2 = pursuing,
   // 3 = acquired) by updating the sim_weapon_status map

--- a/src/InteractRegion.h
+++ b/src/InteractRegion.h
@@ -59,8 +59,8 @@ class InteractRegion
   // the are defined in this sim.
   std::map<std::string, bool> GetDefinedFactors(std::string eqn_type);
 
-  // Returns the master list of all factors to be recorded in database
-  std::vector<std::string>& GetMasterFactors();
+  // Returns the main list of all factors to be recorded in database
+  std::vector<std::string>& GetmainFactors();
 
   // Tracks weapons status of each state (0 = not pursuing, 2 = pursuing,
   // 3 = acquired) by updating the sim_weapon_status map
@@ -139,7 +139,7 @@ bool symmetric;
 // pointers persist
 static std::vector<std::string> column_names;
 
-// Defines which of the master factor list are being used based on weights
+// Defines which of the main factor list are being used based on weights
 std::map<std::string, bool> p_present;
 std::map<std::string, bool> a_present;
 

--- a/src/StateInst.cc
+++ b/src/StateInst.cc
@@ -239,7 +239,7 @@ void StateInst::DeploySecret() {
   // calculated
   
   // Any factors not defined for sim should have a value of zero in the table
-  std::vector<std::string>& main_factors = pseudo_region->GetmainFactors();
+  std::vector<std::string>& main_factors = pseudo_region->GetMainFactors();
   std::map<std::string, bool> present = pseudo_region->DefinedFactors("Pursuit");
 
   double pursuit_eqn = 0;

--- a/src/StateInst.cc
+++ b/src/StateInst.cc
@@ -239,16 +239,16 @@ void StateInst::DeploySecret() {
   // calculated
   
   // Any factors not defined for sim should have a value of zero in the table
-  std::vector<std::string>& master_factors = pseudo_region->GetMasterFactors();
+  std::vector<std::string>& main_factors = pseudo_region->GetmainFactors();
   std::map<std::string, bool> present = pseudo_region->DefinedFactors("Pursuit");
 
   double pursuit_eqn = 0;
 
-  // Iterate through master list of factors. If not present then record 0
+  // Iterate through main list of factors. If not present then record 0
   // in database. If present then calculate current value based on time
   // dynamics
-  for(int f = 0; f < master_factors.size(); f++){
-    const std::string& factor = master_factors[f];
+  for(int f = 0; f < main_factors.size(); f++){
+    const std::string& factor = main_factors[f];
     bool f_defined  = present[std::string(factor)];
     // for most factors 'relation' defines the function for time dynamics of
     // the factor. But for Conflict, 'relation' is the pair state in the


### PR DESCRIPTION
This repository replaces references to `master` with `main` when used in code. This seems fairly uncontroversial and is mainly used in comments and deprecated code.